### PR TITLE
Updates for compatability

### DIFF
--- a/berbix-react-native.podspec
+++ b/berbix-react-native.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/berbix/berbix-ios-spec.git', :tag => s.version.to_s }
 
 
-  s.source_files = "ios/**/*.{h,m,mm,swift}"
+  s.source_files = "ios/*.{h,m,mm,swift}"
 
 
   s.dependency "React-Core"

--- a/ios/BerbixSdk-Bridging-Header.h
+++ b/ios/BerbixSdk-Bridging-Header.h
@@ -1,1 +1,0 @@
-#import <React/RCTBridgeModule.h>

--- a/ios/BerbixSdk.swift
+++ b/ios/BerbixSdk.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Berbix
+import React
 
 public func buildBerbixConfig(config:NSDictionary) -> BerbixConfiguration {
     let clientToken: String = config["clientToken"] as! String

--- a/ios/BerbixSdk.xcodeproj/project.pbxproj
+++ b/ios/BerbixSdk.xcodeproj/project.pbxproj
@@ -25,13 +25,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		134814201AA4EA6300B7C361 /* libBerbixSdk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBerbixSdk.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		134814201AA4EA6300B7C361 /* BerbixSdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BerbixSdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2DC193D9C6FBAA1FB461E4FA /* Pods_BerbixSdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BerbixSdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3633D642915DF211A5E9F8F5 /* Pods-BerbixSdk.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BerbixSdk.debug.xcconfig"; path = "Target Support Files/Pods-BerbixSdk/Pods-BerbixSdk.debug.xcconfig"; sourceTree = "<group>"; };
 		94A91F252528C16A005A84C7 /* FlowDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowDelegate.swift; sourceTree = "<group>"; };
 		A6299D55EDDD34C7626134E2 /* Pods-BerbixSdk.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BerbixSdk.release.xcconfig"; path = "Target Support Files/Pods-BerbixSdk/Pods-BerbixSdk.release.xcconfig"; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* BerbixSdk.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BerbixSdk.m; sourceTree = "<group>"; };
-		F4FF95D5245B92E700C19C63 /* BerbixSdk-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BerbixSdk-Bridging-Header.h"; sourceTree = "<group>"; };
 		F4FF95D6245B92E800C19C63 /* BerbixSdk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BerbixSdk.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -50,7 +49,7 @@
 		134814211AA4EA7D00B7C361 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				134814201AA4EA6300B7C361 /* libBerbixSdk.a */,
+				134814201AA4EA6300B7C361 /* BerbixSdk.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -69,7 +68,6 @@
 				94A91F252528C16A005A84C7 /* FlowDelegate.swift */,
 				F4FF95D6245B92E800C19C63 /* BerbixSdk.swift */,
 				B3E7B5891CC2AC0600A0062D /* BerbixSdk.m */,
-				F4FF95D5245B92E700C19C63 /* BerbixSdk-Bridging-Header.h */,
 				134814211AA4EA7D00B7C361 /* Products */,
 				659FDB4BB22D25D20D48085F /* Pods */,
 				3CCEE6BD8EB49ABCF66BC839 /* Frameworks */,
@@ -103,8 +101,8 @@
 			);
 			name = BerbixSdk;
 			productName = RCTDataManager;
-			productReference = 134814201AA4EA6300B7C361 /* libBerbixSdk.a */;
-			productType = "com.apple.product-type.library.static";
+			productReference = 134814201AA4EA6300B7C361 /* BerbixSdk.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -274,6 +272,7 @@
 			baseConfigurationReference = 3633D642915DF211A5E9F8F5 /* Pods-BerbixSdk.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -284,7 +283,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = BerbixSdk;
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "BerbixSdk-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -295,6 +294,7 @@
 			baseConfigurationReference = A6299D55EDDD34C7626134E2 /* Pods-BerbixSdk.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -305,7 +305,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = BerbixSdk;
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "BerbixSdk-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/ios/FlowDelegate.swift
+++ b/ios/FlowDelegate.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Berbix
+import React
 
 class FlowDelegate: NSObject, BerbixFlowDelegate {
     var resolve: RCTPromiseResolveBlock


### PR DESCRIPTION
1. Ship our RN bridge `berbix-react-native` as a framework instead of a static library
2. Remove bridging header as they are not permitted in frameworks, only app targets.
3. Use modern module import syntax to fix linker errors due to bridge header
4. Disable recursive `source_files` file regex in the subspec. This was adding 1400+ build files and creating circular dependencies