### PR TITLE
chore: bump iOS dependency to 3.0.4

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -7,7 +7,7 @@ target 'BerbixSdk' do
   source 'https://cdn.cocoapods.org/'
   source 'https://github.com/berbix/berbix-ios-spec.git'
 
-  pod 'Berbix', '3.0.1'
+  pod 'Berbix', '3.0.4'
   
   use_frameworks!
 


### PR DESCRIPTION
Bump iOS dependency to 3.0.4 to coincide with pending Android release.