### PR TITLE
Install latest git before checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ jobs:
   install-dependencies:
     executor: default
     steps:
+      # Update to the latest git version in light of CVE-2022-41903 and CVE-2022-41953
+      - run: 'sudo apt-get update'
+      - run: 'sudo apt-get install --only-upgrade git'
       - checkout
       - attach_project
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,3 +139,4 @@ workflows:
       - build-android-example:
           requires:
             - install-dependencies
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,4 +139,3 @@ workflows:
       - build-android-example:
           requires:
             - install-dependencies
-


### PR DESCRIPTION
Installs the latest `git` version before checking out code to address CVE-2022-41903 and CVE-2022-41953. The extra steps take less than a minute, so I don't think the hit to the build time will be too big. I considered pushing a custom image, but decided against it, since the build time hit isn't too big and this approach is a bit more readable IMO.

## Testing
CI passes